### PR TITLE
Develop wendo/next alarms

### DIFF
--- a/lib/ical/alarm.ex
+++ b/lib/ical/alarm.ex
@@ -2,6 +2,7 @@ defmodule ICal.Alarm do
   @moduledoc """
   An iCalendar Alarm
   """
+  @callback next_alarms(event :: ICal.Event.t() | ICal.Todo.t()) :: Enumerable.t(ICal.Alarm.t())
   alias __MODULE__.{Audio, Custom, Display, Email, Trigger}
 
   defstruct action: %Custom{}, trigger: %Trigger{}, custom_properties: %{}

--- a/lib/ical/alarm/alarm_behaviour.ex
+++ b/lib/ical/alarm/alarm_behaviour.ex
@@ -1,0 +1,3 @@
+defmodule Ical.Alarm.AlarmBehaviour do
+    @callback next_alarms(event :: Ical.Event.t()) :: Enumerable.t(Ical.Alarm.t())
+end

--- a/lib/ical/alarm/alarm_behaviour.ex
+++ b/lib/ical/alarm/alarm_behaviour.ex
@@ -1,3 +1,3 @@
 defmodule Ical.Alarm.AlarmBehaviour do
-    @callback next_alarms(event :: Ical.Event.t()) :: Enumerable.t(Ical.Alarm.t())
+  @callback next_alarms(event :: Ical.Event.t()) :: Enumerable.t(Ical.Alarm.t())
 end

--- a/lib/ical/alarm/alarm_behaviour.ex
+++ b/lib/ical/alarm/alarm_behaviour.ex
@@ -1,3 +1,0 @@
-defmodule Ical.Alarm.AlarmBehaviour do
-  @callback next_alarms(event :: Ical.Event.t()) :: Enumerable.t(Ical.Alarm.t())
-end

--- a/lib/ical/event.ex
+++ b/lib/ical/event.ex
@@ -81,4 +81,11 @@ defmodule ICal.Event do
   def next_alarms(%__MODULE__{alarms: []}) do
     Stream.map([nil], fn _ -> [] end)
   end
+
+  def next_alarms(%__MODULE__{} = event) do
+    event
+    |> ICal.Recurrence.stream()
+    |> Stream.map( &(&1.alarms))
+    |> Enum.take(1)
+  end
 end

--- a/lib/ical/event.ex
+++ b/lib/ical/event.ex
@@ -81,7 +81,15 @@ defmodule ICal.Event do
   def next_alarms(%__MODULE__{alarms: []}), do: []
 
   # when the event has no recurrences, but the event is in the future
-  def next_alarms(%__MODULE__{dtstart: dtstart, dtend: dtend, rrule: recurrence, alarms: [%ICal.Alarm{trigger: %ICal.Alarm.Trigger{relative_to: alarm_relative_to}} | _]} = event) when is_nil(recurrence) do
+  def next_alarms(
+        %__MODULE__{
+          dtstart: dtstart,
+          dtend: dtend,
+          rrule: recurrence,
+          alarms: [%ICal.Alarm{trigger: %ICal.Alarm.Trigger{relative_to: alarm_relative_to}} | _]
+        } = event
+      )
+      when is_nil(recurrence) do
     case alarm_relative_to do
       :end ->
         case in_future?(dtend) do
@@ -91,17 +99,16 @@ defmodule ICal.Event do
           true ->
             event.alarms
         end
-    _ ->
-      case in_future?(dtstart) do
+
+      _ ->
+        case in_future?(dtstart) do
           false ->
             []
 
           true ->
             event.alarms
         end
-
     end
-
   end
 
   # when the event has recurrences
@@ -115,6 +122,7 @@ defmodule ICal.Event do
   # True when the event is in the future
   defp in_future?(date) do
     {:ok, date_zone_shifted} = DateTime.shift_zone(date, DateTime.utc_now().time_zone)
+
     case Timex.compare(DateTime.now!("Etc/UTC"), date_zone_shifted) do
       -1 -> true
       _ -> false

--- a/lib/ical/event.ex
+++ b/lib/ical/event.ex
@@ -3,6 +3,8 @@ defmodule ICal.Event do
   An iCalendar Event
   """
 
+  @behaviour Ical.Alarm.AlarmBehaviour
+
   # credo:disable-for-next-line
   defstruct uid: nil,
             dtstamp: nil,
@@ -71,4 +73,12 @@ defmodule ICal.Event do
           resources: [String.t()],
           custom_properties: ICal.custom_properties()
         }
+
+  @doc """
+    Given an event with alarms, list the next alarm(s)
+  """
+  @impl Ical.Alarm.AlarmBehaviour
+  def next_alarms(%__MODULE__{alarms: []}) do
+    Stream.map([nil], fn _ -> [] end)
+  end
 end

--- a/lib/ical/event.ex
+++ b/lib/ical/event.ex
@@ -81,14 +81,27 @@ defmodule ICal.Event do
   def next_alarms(%__MODULE__{alarms: []}), do: []
 
   # when the event has no recurrences, but the event is in the future
-  def next_alarms(%__MODULE__{dtend: dtend, rrule: recurrence} = event) when is_nil(recurrence) do
-    case in_future?(dtend) do
-      false ->
-        []
+  def next_alarms(%__MODULE__{dtstart: dtstart, dtend: dtend, rrule: recurrence, alarms: [%ICal.Alarm{trigger: %ICal.Alarm.Trigger{relative_to: alarm_relative_to}} | _]} = event) when is_nil(recurrence) do
+    case alarm_relative_to do
+      :end ->
+        case in_future?(dtend) do
+          false ->
+            []
 
-      true ->
-        event.alarms
+          true ->
+            event.alarms
+        end
+    _ ->
+      case in_future?(dtstart) do
+          false ->
+            []
+
+          true ->
+            event.alarms
+        end
+
     end
+
   end
 
   # when the event has recurrences
@@ -101,7 +114,8 @@ defmodule ICal.Event do
 
   # True when the event is in the future
   defp in_future?(date) do
-    case Timex.compare(DateTime.now!("Etc/UTC"), date) do
+    {:ok, date_zone_shifted} = DateTime.shift_zone(date, DateTime.utc_now().time_zone)
+    case Timex.compare(DateTime.now!("Etc/UTC"), date_zone_shifted) do
       -1 -> true
       _ -> false
     end

--- a/lib/ical/event.ex
+++ b/lib/ical/event.ex
@@ -3,7 +3,7 @@ defmodule ICal.Event do
   An iCalendar Event
   """
 
-  @behaviour Ical.Alarm.AlarmBehaviour
+  @behaviour ICal.Alarm
 
   # credo:disable-for-next-line
   defstruct uid: nil,
@@ -77,15 +77,33 @@ defmodule ICal.Event do
   @doc """
     Given an event with alarms, list the next alarm(s)
   """
-  @impl Ical.Alarm.AlarmBehaviour
-  def next_alarms(%__MODULE__{alarms: []}) do
-    Stream.map([nil], fn _ -> [] end)
+  @impl ICal.Alarm
+  def next_alarms(%__MODULE__{alarms: []}), do: []
+
+  # when the event has no recurrences, but the event is in the future
+  def next_alarms(%__MODULE__{dtend: dtend, rrule: recurrence} = event) when is_nil(recurrence) do
+    case in_future?(dtend) do
+      false ->
+        []
+
+      true ->
+        event.alarms
+    end
   end
 
-  def next_alarms(%__MODULE__{} = event) do
+  # when the event has recurrences
+  def next_alarms(%__MODULE__{rrule: recurrence} = event) when not is_nil(recurrence) do
     event
     |> ICal.Recurrence.stream()
-    |> Stream.map( &(&1.alarms))
+    |> Stream.map(& &1.alarms)
     |> Enum.take(1)
+  end
+
+  # True when the event is in the future
+  defp in_future?(date) do
+    case Timex.compare(DateTime.now!("Etc/UTC"), date) do
+      -1 -> true
+      _ -> false
+    end
   end
 end

--- a/lib/ical/recurrence.ex
+++ b/lib/ical/recurrence.ex
@@ -106,7 +106,7 @@ defmodule ICal.Recurrence do
       iex> dt_end = Timex.to_date({2016, 8, 23})
       iex> event = %ICal.Event{rrule: %ICal.Recurrence{frequency: :daily}, dtstart: dt, dtend: dt}
       iex> recurrences =
-            ICal.Recurrence.get_recurrences(event)
+            ICal.Recurrence.stream(event)
             |> Enum.to_list()
   """
 

--- a/lib/ical/todo.ex
+++ b/lib/ical/todo.ex
@@ -2,6 +2,7 @@ defmodule ICal.Todo do
   @moduledoc """
   An iCalendar TODO component.
   """
+  @behaviour ICal.Alarm
 
   # credo:disable-for-next-line
   defstruct [
@@ -77,4 +78,28 @@ defmodule ICal.Todo do
           resources: [String.t()],
           custom_properties: ICal.custom_properties()
         }
+
+  @impl ICal.Alarm
+  @spec next_alarms(ICal.Todo.t()) :: Enumerable.t(ICal.Alarm.t())
+  def next_alarms(%__MODULE__{alarms: []}), do: []
+
+  # when the todo has no recurrences, but the todo is in the future
+  def next_alarms(%__MODULE__{dtstart: dtstart, rrule: recurrence} = todo)
+      when is_nil(recurrence) do
+    case in_future?(dtstart) do
+      false ->
+        []
+
+      true ->
+        todo.alarms
+    end
+  end
+
+  # True when the todo is in the future
+  defp in_future?(date) do
+    case Timex.compare(DateTime.now!("Etc/UTC"), date) do
+      -1 -> true
+      _ -> false
+    end
+  end
 end

--- a/lib/ical/todo.ex
+++ b/lib/ical/todo.ex
@@ -98,6 +98,7 @@ defmodule ICal.Todo do
   # True when the event is in the future
   defp in_future?(date) do
     {:ok, date_zone_shifted} = DateTime.shift_zone(date, DateTime.utc_now().time_zone)
+
     case Timex.compare(DateTime.now!("Etc/UTC"), date_zone_shifted) do
       -1 -> true
       _ -> false

--- a/lib/ical/todo.ex
+++ b/lib/ical/todo.ex
@@ -95,9 +95,10 @@ defmodule ICal.Todo do
     end
   end
 
-  # True when the todo is in the future
+  # True when the event is in the future
   defp in_future?(date) do
-    case Timex.compare(DateTime.now!("Etc/UTC"), date) do
+    {:ok, date_zone_shifted} = DateTime.shift_zone(date, DateTime.utc_now().time_zone)
+    case Timex.compare(DateTime.now!("Etc/UTC"), date_zone_shifted) do
       -1 -> true
       _ -> false
     end

--- a/test/ical/event_test.exs
+++ b/test/ical/event_test.exs
@@ -262,4 +262,20 @@ defmodule ICal.EventTest do
     |> ICal.to_ics()
     |> assert_fully_contains(expected)
   end
+
+  test "next_alarm/1" do
+    event_with_alarm = Fixtures.one_event(:deserialize, {:alarm, true})
+
+    next_alarms = ICal.Event.next_alarms(event_with_alarm) |> Enum.take(1)
+    expected_next_alarm = %ICal.Alarm{
+                action: %ICal.Alarm.Audio{
+                  duration: %ICal.Duration{positive: true, time: {0, 15, 0}, days: 0, weeks: 0},
+                  attachments: [%ICal.Attachment{data_type: :uri, data: "ftp://example.com/pub/sounds/bell-01.aud", mimetype: "audio/basic"}],
+                  repeat: 0
+                },
+                custom_properties: %{},
+                trigger: %ICal.Alarm.Trigger{on: ~U[1997-03-17 13:30:00Z], relative_to: nil, repeat: 4}
+              }
+    assert [expected_next_alarm] == next_alarms
+  end
 end

--- a/test/ical/event_test.exs
+++ b/test/ical/event_test.exs
@@ -263,19 +263,27 @@ defmodule ICal.EventTest do
     |> assert_fully_contains(expected)
   end
 
-  test "next_alarm/1" do
-    event_with_alarm = Fixtures.one_event(:deserialize, {:alarm, true})
+  test "next_alarm/1 for an event with recurrences" do
+    event_with_alarm = Fixtures.one_event(:one_alarm)
 
-    next_alarms = ICal.Event.next_alarms(event_with_alarm) |> Enum.take(1)
-    expected_next_alarm = %ICal.Alarm{
-                action: %ICal.Alarm.Audio{
-                  duration: %ICal.Duration{positive: true, time: {0, 15, 0}, days: 0, weeks: 0},
-                  attachments: [%ICal.Attachment{data_type: :uri, data: "ftp://example.com/pub/sounds/bell-01.aud", mimetype: "audio/basic"}],
-                  repeat: 0
-                },
-                custom_properties: %{},
-                trigger: %ICal.Alarm.Trigger{on: ~U[1997-03-17 13:30:00Z], relative_to: nil, repeat: 4}
-              }
-    assert [expected_next_alarm] == next_alarms
+    actual_next_alarms = ICal.Event.next_alarms(event_with_alarm)
+    expected_next_alarm = Fixtures.alarm(:audio)
+    assert [expected_next_alarm] == actual_next_alarms
+  end
+
+  test "next_alarm/1 for an event with no alarm" do
+    event_without_alarm = Fixtures.one_event(:deserialize)
+
+    actual_next_alarms = ICal.Event.next_alarms(event_without_alarm)
+    assert [] == actual_next_alarms
+  end
+
+  test "next_alarm/1 for an event with no recurrences, but occurs in future" do
+    event_without_recurrences = Fixtures.one_event(:future_no_recurrences)
+
+    actual_next_alarms = ICal.Event.next_alarms(event_without_recurrences)
+    expected_next_alarms = Fixtures.alarm(:audio)
+
+    assert [expected_next_alarms] == actual_next_alarms
   end
 end

--- a/test/ical/event_test.exs
+++ b/test/ical/event_test.exs
@@ -282,7 +282,16 @@ defmodule ICal.EventTest do
     event_without_recurrences = Fixtures.one_event(:future_no_recurrences)
 
     actual_next_alarms = ICal.Event.next_alarms(event_without_recurrences)
-    expected_next_alarms = Fixtures.alarm(:audio)
+    expected_next_alarms = Fixtures.alarm(:trigger_start)
+
+    assert [expected_next_alarms] == actual_next_alarms
+  end
+
+  test "next_alarm/1 for an event with no recurrences, but trigger for alarm is `:end`, and end is in future" do
+    event_without_recurrences = Fixtures.one_event(:future_no_recurrences_trigger_end)
+
+    actual_next_alarms = ICal.Event.next_alarms(event_without_recurrences)
+    expected_next_alarms = Fixtures.alarm(:trigger_end)
 
     assert [expected_next_alarms] == actual_next_alarms
   end

--- a/test/ical/todo_test.exs
+++ b/test/ical/todo_test.exs
@@ -35,4 +35,29 @@ defmodule ICal.TodoTest do
     |> ICal.to_ics()
     |> assert_fully_contains(expected)
   end
+
+  @tag :skip
+  test "next_alarm/1 for a todo with recurrences" do
+    todo_with_alarm = Fixtures.todo(:one_alarm)
+
+    actual_next_alarms = ICal.Todo.next_alarms(todo_with_alarm)
+    expected_next_alarm = Fixtures.alarm(:audio)
+    assert [expected_next_alarm] == actual_next_alarms
+  end
+
+  test "next_alarm/1 for a todo with no alarm" do
+    todo_without_alarm = Fixtures.todo("20070313T123432Z-456553@example.com")
+
+    actual_next_alarms = ICal.Todo.next_alarms(todo_without_alarm)
+    assert [] == actual_next_alarms
+  end
+
+  test "next_alarm/1 for a todo with no recurrences, but occurs in future" do
+    todo_without_recurrences = Fixtures.todo(:future_no_recurrences)
+
+    actual_next_alarms = ICal.Todo.next_alarms(todo_without_recurrences)
+    expected_next_alarms = Fixtures.alarm(:audio)
+
+    assert [expected_next_alarms] == actual_next_alarms
+  end
 end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -114,59 +114,20 @@ defmodule ICal.Test.Fixtures do
     }
   end
 
-  def one_event(:deserialize, {:alarm, true}) do
-    %ICal.Event{
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
-      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
-      summary: "Going fishing",
-      description: "Escape from the world. Stare at some water.",
-      location: "123 Fun Street, Toronto ON, Canada",
-      status: :tentative,
-      categories: ["Fishing", "Nature"],
-      comments: ["Don't forget to take something to eat !"],
-      contacts: [
-        %ICal.Contact{
-          alternative_representation:
-            "ldap:ldap://example.com:6666/o=ABC% 20Industries,c=US???(cn=Beat%20Fuss)",
-          language: "de",
-          value: "Beat Fuss"
-        },
-        %ICal.Contact{value: "Jill Bar"}
-      ],
-      created: ~U[1996-03-29 13:30:00Z],
-      class: "PRIVATE",
-      duration: %ICal.Duration{
-        days: 15,
-        positive: true,
-        time: {5, 0, 20},
-        weeks: 0
-      },
-      geo: {43.6978819, -79.3810277},
-      modified: ~U[1996-08-17 13:30:00Z],
-      organizer: "mailto:jsmith@example.com",
-      priority: 2,
-      related_to: ["jsmith.part7.19960817T083000.xyzMail@example.com"],
-      resources: ["EASEL", "PROJECTOR", "VCR"],
-      sequence: 1000,
-      uid: "1001",
-      alarms: alarm(:audio),
-      rrule: %ICal.Recurrence{
-        until: nil,
-        count: nil,
-        by_second: nil,
-        by_minute: nil,
-        by_hour: nil,
-        by_day: nil,
-        by_month_day: nil,
-        by_year_day: nil,
-        by_month: nil,
-        by_set_position: nil,
-        by_week_number: nil,
-        weekday: nil,
-        frequency: :daily,
-        interval: 1
-      }
+  def one_event(:one_alarm) do
+    %{
+      one_event(:deserialize)
+      | rrule: %ICal.Recurrence{frequency: :daily, interval: 1},
+        alarms: alarm(:audio)
+    }
+  end
+
+  def one_event(:future_no_recurrences) do
+    %{
+      one_event(:deserialize)
+      | rrule: nil,
+        dtend: DateTime.new!(~D[2100-01-01], ~T[00:00:00.000], "Etc/UTC"),
+        alarms: [alarm(:audio)]
     }
   end
 
@@ -718,6 +679,29 @@ defmodule ICal.Test.Fixtures do
       summary: "Submit Quebec Income Tax Return for 2006",
       uid: "20070313T123432Z-456553@example.com",
       url: nil
+    }
+  end
+
+  def todo(:one_alarm) do
+    %{
+      todo("20070313T123432Z-456553@example.com")
+      | alarms: alarm(:audio)
+    }
+  end
+
+  def todo(:repeating) do
+    %{
+      todo("20070313T123432Z-456553@example.com")
+      | alarms: alarm(:audio),
+        rrule: %ICal.Recurrence{frequency: :daily, interval: 1}
+    }
+  end
+
+  def todo(:future_no_recurrences) do
+    %{
+      todo("20070313T123432Z-456553@example.com")
+      | alarms: [alarm(:audio)],
+        dtstart: DateTime.new!(~D[2100-01-01], ~T[00:00:00.000], "Etc/UTC")
     }
   end
 

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -114,6 +114,62 @@ defmodule ICal.Test.Fixtures do
     }
   end
 
+  def one_event(:deserialize, {:alarm, true}) do
+    %ICal.Event{
+      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
+      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
+      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+      summary: "Going fishing",
+      description: "Escape from the world. Stare at some water.",
+      location: "123 Fun Street, Toronto ON, Canada",
+      status: :tentative,
+      categories: ["Fishing", "Nature"],
+      comments: ["Don't forget to take something to eat !"],
+      contacts: [
+        %ICal.Contact{
+          alternative_representation:
+            "ldap:ldap://example.com:6666/o=ABC% 20Industries,c=US???(cn=Beat%20Fuss)",
+          language: "de",
+          value: "Beat Fuss"
+        },
+        %ICal.Contact{value: "Jill Bar"}
+      ],
+      created: ~U[1996-03-29 13:30:00Z],
+      class: "PRIVATE",
+      duration: %ICal.Duration{
+        days: 15,
+        positive: true,
+        time: {5, 0, 20},
+        weeks: 0
+      },
+      geo: {43.6978819, -79.3810277},
+      modified: ~U[1996-08-17 13:30:00Z],
+      organizer: "mailto:jsmith@example.com",
+      priority: 2,
+      related_to: ["jsmith.part7.19960817T083000.xyzMail@example.com"],
+      resources: ["EASEL", "PROJECTOR", "VCR"],
+      sequence: 1000,
+      uid: "1001",
+      alarms: alarm(:audio),
+      rrule: %ICal.Recurrence{
+        until: nil,
+        count: nil,
+        by_second: nil,
+        by_minute: nil,
+        by_hour: nil,
+        by_day: nil,
+        by_month_day: nil,
+        by_year_day: nil,
+        by_month: nil,
+        by_set_position: nil,
+        by_week_number: nil,
+        weekday: nil,
+        frequency: :daily,
+        interval: 1
+      }
+    }
+  end
+
   def uid_only_event do
     %ICal.Event{
       uid: "YES",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -126,8 +126,18 @@ defmodule ICal.Test.Fixtures do
     %{
       one_event(:deserialize)
       | rrule: nil,
-        dtend: DateTime.new!(~D[2100-01-01], ~T[00:00:00.000], "Etc/UTC"),
-        alarms: [alarm(:audio)]
+        dtstart: DateTime.new!(~D[2100-01-01], ~T[00:00:00.000], "Etc/UTC"),
+        alarms: [alarm(:trigger_start)]
+    }
+  end
+
+  def one_event(:future_no_recurrences_trigger_end) do
+    %{
+      one_event(:deserialize)
+      | rrule: nil,
+        dtstart: DateTime.new!(~D[2100-01-01], ~T[00:00:00.000], "Etc/UTC"),
+        dtend: DateTime.new!(~D[2100-01-01], ~T[00:30:00.000], "Etc/UTC"),
+        alarms: [alarm(:trigger_end)]
     }
   end
 
@@ -499,6 +509,26 @@ defmodule ICal.Test.Fixtures do
         relative_to: nil,
         repeat: 4,
         on: ~U[1997-03-17 13:30:00Z]
+      }
+    }
+  end
+
+  def alarm(:trigger_end) do
+    %{
+      alarm(:audio) | trigger: %ICal.Alarm.Trigger{
+        relative_to: :end,
+        repeat: 4,
+        on: ~U[2100-03-17 13:30:00Z]
+      }
+    }
+  end
+
+  def alarm(:trigger_start) do
+    %{
+      alarm(:audio) | trigger: %ICal.Alarm.Trigger{
+        relative_to: :start,
+        repeat: 4,
+        on: ~U[2100-03-17 13:30:00Z]
       }
     }
   end

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -515,21 +515,23 @@ defmodule ICal.Test.Fixtures do
 
   def alarm(:trigger_end) do
     %{
-      alarm(:audio) | trigger: %ICal.Alarm.Trigger{
-        relative_to: :end,
-        repeat: 4,
-        on: ~U[2100-03-17 13:30:00Z]
-      }
+      alarm(:audio)
+      | trigger: %ICal.Alarm.Trigger{
+          relative_to: :end,
+          repeat: 4,
+          on: ~U[2100-03-17 13:30:00Z]
+        }
     }
   end
 
   def alarm(:trigger_start) do
     %{
-      alarm(:audio) | trigger: %ICal.Alarm.Trigger{
-        relative_to: :start,
-        repeat: 4,
-        on: ~U[2100-03-17 13:30:00Z]
-      }
+      alarm(:audio)
+      | trigger: %ICal.Alarm.Trigger{
+          relative_to: :start,
+          repeat: 4,
+          on: ~U[2100-03-17 13:30:00Z]
+        }
     }
   end
 


### PR DESCRIPTION
- added a behaviour in `alarm_behaviour.ex`. Todo and Event should implement this behaviour.
- Updated event test to get the list of the next alarm.
- Updated fixtures with function one_event/2 to return an event with alarms and rrule values.