### PR TITLE
Replace Timex with stdlib in all test files

### DIFF
--- a/test/ical/deserialize_test.exs
+++ b/test/ical/deserialize_test.exs
@@ -267,8 +267,8 @@ defmodule ICal.DeserializeTest do
       %ICal{events: [event]} = ICal.from_ics(ics)
 
       assert event == %Event{
-               dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
-               dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
+               dtstart: ~U[2015-12-24 08:30:00Z],
+               dtend: ~U[2015-12-24 08:45:00Z],
                summary:
                  "Going fishing at the lake that happens to be in the middle of fun street.",
                description:
@@ -323,7 +323,7 @@ defmodule ICal.DeserializeTest do
     test "Event with RECURRENCE-ID with TZID" do
       ics = Helper.test_data("event_with_recurrence_id_tz")
       %ICal{events: [event]} = ICal.from_ics(ics)
-      expected = Timex.Timezone.convert(~U[2020-09-17 18:30:00Z], "America/Toronto")
+      expected = DateTime.shift_zone!(~U[2020-09-17 18:30:00Z], "America/Toronto")
       assert event.recurrence_id == expected
     end
 

--- a/test/ical/event_test.exs
+++ b/test/ical/event_test.exs
@@ -11,7 +11,7 @@ defmodule ICal.EventTest do
     END:VEVENT
     """
 
-    %Event{dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})}
+    %Event{dtstamp: ~U[2015-12-24 08:45:00Z]}
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
   end
@@ -34,9 +34,9 @@ defmodule ICal.EventTest do
     """
 
     %Event{
-      dtstart: Timex.to_date({2015, 12, 24}),
-      dtend: Timex.to_date({2015, 12, 24}),
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstart: ~D[2015-12-24],
+      dtend: ~D[2015-12-24],
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -52,9 +52,9 @@ defmodule ICal.EventTest do
     """
 
     %Event{
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstart: ~U[2015-12-24 08:30:00Z],
+      dtend: ~U[2015-12-24 08:45:00Z],
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -73,8 +73,8 @@ defmodule ICal.EventTest do
 
     %ICal.Event{
       summary: "Film with Amy and Adam",
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+      dtstart: ~U[2015-12-24 08:30:00Z],
+      dtend: ~U[2015-12-24 08:45:00Z],
       description: "Let's go see Star Wars, and have fun."
     }
     |> ICal.Serialize.Event.component()
@@ -90,18 +90,14 @@ defmodule ICal.EventTest do
     END:VEVENT
     """
 
-    dtstart =
-      {{2015, 12, 24}, {8, 30, 00}}
-      |> Timex.to_datetime("America/Chicago")
+    dtstart = DateTime.new!(~D[2015-12-24], ~T[08:30:00], "America/Chicago")
 
-    dtend =
-      {{2015, 12, 24}, {8, 45, 00}}
-      |> Timex.to_datetime("America/Chicago")
+    dtend = DateTime.new!(~D[2015-12-24], ~T[08:45:00], "America/Chicago")
 
     %Event{
       dtstart: dtstart,
       dtend: dtend,
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -121,7 +117,7 @@ defmodule ICal.EventTest do
       description:
         "See this link http://example.com/pub" <>
           "/calendars/jsmith/mytime.ics",
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -137,7 +133,7 @@ defmodule ICal.EventTest do
 
     %Event{
       url: "http://example.com/pub/calendars/jsmith/mytime.ics",
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -153,7 +149,7 @@ defmodule ICal.EventTest do
 
     %Event{
       uid: 815,
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -169,7 +165,7 @@ defmodule ICal.EventTest do
 
     %Event{
       uid: "0815",
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -185,7 +181,7 @@ defmodule ICal.EventTest do
 
     %Event{
       geo: {43.6978819, -79.3810277},
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -201,7 +197,7 @@ defmodule ICal.EventTest do
 
     %Event{
       categories: ["Fishing", "Nature", "Sport"],
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -217,7 +213,7 @@ defmodule ICal.EventTest do
 
     %Event{
       status: :tentative,
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)
@@ -233,7 +229,7 @@ defmodule ICal.EventTest do
 
     %Event{
       class: :private,
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}})
+      dtstamp: ~U[2015-12-24 08:45:00Z]
     }
     |> ICal.Serialize.Event.component()
     |> assert_fully_contains(expected)

--- a/test/ical/value_test.exs
+++ b/test/ical/value_test.exs
@@ -4,12 +4,12 @@ defmodule ICal.ValueTest do
   alias ICal.Serialize
 
   test "value of a date" do
-    result = Serialize.value(Timex.to_date({2016, 1, 4}))
+    result = Serialize.value(~D[2016-01-04])
     assert result == "20160104"
   end
 
   test "value of a datetime" do
-    result = Serialize.value(Timex.to_datetime({{2016, 1, 4}, {0, 42, 23}}))
+    result = Serialize.value(~U[2016-01-04 00:42:23Z])
     assert result == "20160104T004223Z"
   end
 

--- a/test/ical_test.exs
+++ b/test/ical_test.exs
@@ -78,7 +78,7 @@ defmodule ICalTest do
   end
 
   test "ICal with custom tz alter dates" do
-    dtstamp = Timex.to_datetime({{2015, 12, 24}, {8, 0, 00}})
+    dtstamp = ~U[2015-12-24 08:00:00Z]
 
     %ICal{events: [%ICal.Event{dtstamp: parsed_date}]} =
       Helper.test_data("custom_calendar_tz") |> ICal.from_ics()
@@ -112,16 +112,16 @@ defmodule ICalTest do
     events = [
       %ICal.Event{
         summary: "Film with Amy and Adam",
-        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-        dtstamp: Timex.to_datetime({{2015, 12, 23}, {19, 00, 00}}),
-        dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+        dtstart: ~U[2015-12-24 08:30:00Z],
+        dtstamp: ~U[2015-12-23 19:00:00Z],
+        dtend: ~U[2015-12-24 08:45:00Z],
         description: "Let's go see Star Wars."
       },
       %ICal.Event{
         summary: "Morning meeting",
-        dtstart: Timex.to_datetime({{2015, 12, 24}, {19, 00, 00}}),
-        dtstamp: Timex.to_datetime({{2015, 12, 24}, {15, 00, 00}}),
-        dtend: Timex.to_datetime({{2015, 12, 24}, {22, 30, 00}}),
+        dtstart: ~U[2015-12-24 19:00:00Z],
+        dtstamp: ~U[2015-12-24 15:00:00Z],
+        dtend: ~U[2015-12-24 22:30:00Z],
         description: "A big long meeting with lots of details."
       }
     ]
@@ -150,9 +150,9 @@ defmodule ICalTest do
     events = [
       %ICal.Event{
         summary: "Film with Amy and Adam",
-        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-        dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 00}}),
-        dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+        dtstart: ~U[2015-12-24 08:30:00Z],
+        dtstamp: ~U[2015-12-24 08:00:00Z],
+        dtend: ~U[2015-12-24 08:45:00Z],
         description: "Let's go see Star Wars, and have fun.",
         location: "123 Fun Street, Toronto ON, Canada"
       }
@@ -183,9 +183,9 @@ defmodule ICalTest do
     events = [
       %ICal.Event{
         summary: "Film with Amy and Adam",
-        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-        dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 00}}),
-        dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+        dtstart: ~U[2015-12-24 08:30:00Z],
+        dtstamp: ~U[2015-12-24 08:00:00Z],
+        dtend: ~U[2015-12-24 08:45:00Z],
         description: "Let's go see Star Wars, and have fun.",
         location: "123 Fun Street, Toronto ON, Canada",
         url: "http://example.com/tr3GE5"
@@ -201,8 +201,8 @@ defmodule ICalTest do
     events = [
       %ICal.Event{
         exdates: [
-          Timex.Timezone.convert(~U[2020-09-16 18:30:00Z], "America/Toronto"),
-          Timex.Timezone.convert(~U[2020-09-17 18:30:00Z], "America/Toronto")
+          DateTime.shift_zone!(~U[2020-09-16 18:30:00Z], "America/Toronto"),
+          DateTime.shift_zone!(~U[2020-09-17 18:30:00Z], "America/Toronto")
         ]
       }
     ]
@@ -253,7 +253,7 @@ defmodule ICalTest do
   end
 
   test "ICalender.to_ics/1 with RECURRENCE-ID with timezone" do
-    recurrence_id = Timex.Timezone.convert(~U[2020-09-17 18:30:00Z], "America/Toronto")
+    recurrence_id = DateTime.shift_zone!(~U[2020-09-17 18:30:00Z], "America/Toronto")
 
     events = [
       %ICal.Event{
@@ -274,9 +274,9 @@ defmodule ICalTest do
     events = [
       %ICal.Event{
         summary: "Film with Amy and Adam",
-        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-        dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 00}}),
-        dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+        dtstart: ~U[2015-12-24 08:30:00Z],
+        dtstamp: ~U[2015-12-24 08:00:00Z],
+        dtend: ~U[2015-12-24 08:45:00Z],
         description: "Let's go see Star Wars, and have fun.",
         location: "123 Fun Street, Toronto ON, Canada",
         url: "http://www.example.com"
@@ -296,9 +296,9 @@ defmodule ICalTest do
     events = [
       %ICal.Event{
         summary: "Film with Amy and Adam",
-        dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-        dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
-        dtstamp: Timex.to_datetime({{2017, 12, 24}, {8, 00, 00}}),
+        dtstart: ~U[2015-12-24 08:30:00Z],
+        dtend: ~U[2015-12-24 08:45:00Z],
+        dtstamp: ~U[2017-12-24 08:00:00Z],
         description: "First line\nThis is a new line\n\nDouble newline",
         location: "123 Fun Street, Toronto ON, Canada",
         url: "http://www.example.com"

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -6,16 +6,16 @@ defmodule ICal.Test.Fixtures do
       events: [
         %ICal.Event{
           summary: "Film with Amy and Adam",
-          dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 00}}),
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 00}}),
-          dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+          dtstart: ~U[2015-12-24 08:30:00Z],
+          dtstamp: ~U[2015-12-24 08:00:00Z],
+          dtend: ~U[2015-12-24 08:45:00Z],
           description: "Let's go see Star Wars."
         },
         %ICal.Event{
           summary: "Morning meeting",
-          dtstart: Timex.to_datetime({{2015, 12, 24}, {19, 00, 00}}),
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {18, 00, 00}}),
-          dtend: Timex.to_datetime({{2015, 12, 24}, {22, 30, 00}}),
+          dtstart: ~U[2015-12-24 19:00:00Z],
+          dtstamp: ~U[2015-12-24 18:00:00Z],
+          dtend: ~U[2015-12-24 22:30:00Z],
           description: "A big long meeting with lots of details."
         }
       ]
@@ -29,8 +29,8 @@ defmodule ICal.Test.Fixtures do
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water.",
       comments: ["Don't forget to take something to eat !"],
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
-      created: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
+      dtstamp: ~U[2015-12-24 08:45:00Z],
+      created: ~U[2015-12-24 08:45:00Z],
       contacts: [
         %ICal.Contact{
           alternative_representation:
@@ -77,9 +77,9 @@ defmodule ICal.Test.Fixtures do
 
   def one_event(:deserialize) do
     %ICal.Event{
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
-      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+      dtstart: ~U[2015-12-24 08:30:00Z],
+      dtend: ~U[2015-12-24 08:45:00Z],
+      dtstamp: ~U[2015-12-24 08:00:00Z],
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water.",
       location: "123 Fun Street, Toronto ON, Canada",
@@ -172,7 +172,7 @@ defmodule ICal.Test.Fixtures do
       events: [
         %ICal.Event{
           uid: "1",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+          dtstamp: ~U[2015-12-24 08:00:00Z],
           rdates: [
             ~D[1997-01-01],
             ~D[1997-01-20],
@@ -183,7 +183,7 @@ defmodule ICal.Test.Fixtures do
         },
         %ICal.Event{
           uid: "2",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+          dtstamp: ~U[2015-12-24 08:00:00Z],
           rdates: [
             ~D[1997-01-01],
             ~D[1997-01-20],
@@ -193,7 +193,7 @@ defmodule ICal.Test.Fixtures do
         },
         %ICal.Event{
           uid: "3",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+          dtstamp: ~U[2015-12-24 08:00:00Z],
           rdates: [
             {~U[1997-01-01 18:00:00Z], ~U[1997-01-02 07:00:00Z]},
             {~U[1998-01-01 18:00:00Z], ~U[1998-01-02 07:00:00Z]},
@@ -203,19 +203,19 @@ defmodule ICal.Test.Fixtures do
         },
         %ICal.Event{
           uid: "4",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "5",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "6",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "7",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         }
       ]
     }
@@ -226,7 +226,7 @@ defmodule ICal.Test.Fixtures do
       events: [
         %ICal.Event{
           uid: "1",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+          dtstamp: ~U[2015-12-24 08:00:00Z],
           contacts: [
             %ICal.Contact{
               alternative_representation: "CID:part3.msg970930T083000SILVER@example.com",
@@ -257,22 +257,22 @@ defmodule ICal.Test.Fixtures do
         %ICal.Event{
           uid: "1",
           status: :tentative,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "2",
           status: :confirmed,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "3",
           status: :cancelled,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "4",
           status: nil,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         }
       ]
     }
@@ -284,27 +284,27 @@ defmodule ICal.Test.Fixtures do
         %ICal.Event{
           uid: "1",
           status: :tentative,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "2",
           status: :confirmed,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "3",
           status: :cancelled,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "4",
           status: nil,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         },
         %ICal.Event{
           uid: "5",
           status: "CUSTOM",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}})
+          dtstamp: ~U[2015-12-24 08:00:00Z]
         }
       ]
     }
@@ -312,9 +312,9 @@ defmodule ICal.Test.Fixtures do
 
   def one_truncated_event do
     %ICal.Event{
-      dtstart: Timex.to_datetime({{2015, 12, 24}, {8, 30, 0}}),
-      dtend: Timex.to_datetime({{2015, 12, 24}, {8, 45, 0}}),
-      dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 0}}),
+      dtstart: ~U[2015-12-24 08:30:00Z],
+      dtend: ~U[2015-12-24 08:45:00Z],
+      dtstamp: ~U[2015-12-24 08:00:00Z],
       summary: "Going fishing",
       description: "Escape from the world. Stare at some water.",
       location: "123 Fun Street, Toronto ON, Canada",
@@ -387,7 +387,7 @@ defmodule ICal.Test.Fixtures do
           created: nil,
           dtstart: nil,
           dtend: nil,
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 00, 00}}),
+          dtstamp: ~U[2015-12-24 08:00:00Z],
           modified: nil,
           recurrence_id: nil,
           exdates: [],
@@ -466,11 +466,11 @@ defmodule ICal.Test.Fixtures do
       events: [
         %ICal.Event{
           uid: "1",
-          dtstamp: Timex.to_datetime({{2015, 12, 24}, {8, 45, 00}}),
-          dtend: Timex.to_datetime({{2015, 12, 24}, {12, 45, 00}}),
-          created: Timex.to_datetime({{2015, 11, 24}, {8, 45, 00}}),
+          dtstamp: ~U[2015-12-24 08:45:00Z],
+          dtend: ~U[2015-12-24 12:45:00Z],
+          created: ~U[2015-11-24 08:45:00Z],
           rrule: %ICal.Recurrence{
-            until: Timex.to_datetime({{2019, 11, 24}, {8, 45, 00}}),
+            until: ~U[2019-11-24 08:45:00Z],
             count: 3,
             by_second: [1],
             by_minute: [2],


### PR DESCRIPTION
This is a bit of a bigger one, but it's all straightforward replacement of Timex functions with sigils or functions from the stdlib.

Should be basically the last bit of work for #32! 