### PR TITLE
Fix newline character in draft status serialization

### DIFF
--- a/lib/ical/serialize/component.ex
+++ b/lib/ical/serialize/component.ex
@@ -112,7 +112,7 @@ defmodule ICal.Serialize.Component do
             :cancelled -> ["STATUS:CANCELLED\n"]
             :needs_action -> ["STATUS:NEEDS-ACTION\n"]
             :in_process -> ["STATUS:IN-PROCESS\n"]
-            :draft -> ["STATUS:DRAFT\̣n"]
+            :draft -> ["STATUS:DRAFT\n"]
             :final -> ["STATUS:FINAL\n"]
             value -> [ICal.Serialize.kv("STATUS", to_string(value))]
           end


### PR DESCRIPTION
There was a strange unicode character in here that probably shouldn't be in there – it added a diacritic to the `\` in the newline \.